### PR TITLE
Set Default Images

### DIFF
--- a/src/js/bookmarklet.js
+++ b/src/js/bookmarklet.js
@@ -1,12 +1,13 @@
 /**
   Pullquote Bookmarklet
-*/ 
+*/
 function iFrame() {
 
     function init() {
         event.preventDefault();
         text = grabTextSelection();
-        url = composeURL(text, "assets/placeholder.jpg", "publication name")
+        image = grabOgImage();
+        url = composeURL(text, image, "publication name")
         bookMarklet = document.createElement('div');
         bookMarklet.className = 'bookMarklet';
         bookMarklet.innerHTML = "<button class='closeButton' onClick='bookmarklet.iFrame().closeiFrame()'></button><iframe src='" + url + "'></iframe><div class='backdrop'></div>";
@@ -21,6 +22,12 @@ function iFrame() {
       text = window.getSelection().toString();
 
       return text;
+    }
+
+    function grabOgImage() {
+      var image = document.querySelectorAll("meta[property='og:image']")[0].content;
+
+      return image;
     }
 
     function composeURL(quote, image, cite) {


### PR DESCRIPTION
**What?**
We use the query selector to find the og:image if there is one, if there isn't, we just set the image to transparent.gif so the resulting image is a black box

**Why?**
This should cover us in many cases for selecting an image (as long as there's an og:tag) and we can be fairly confident that in the cases where there is and og image it will be a quality one. Once we see this in action, we might want to develop a third path for finding satisfactory images that aren't tagged as og, but this seems like a sensible start to me.

**cc** @shortdiv 
