### PR TITLE
fix: Changing css compile file name

### DIFF
--- a/tasks/minify-css.js
+++ b/tasks/minify-css.js
@@ -1,6 +1,6 @@
 var cssmin = require('cssmin'),
     fs = require('fs-extra'),
-    css = fs.readFileSync("dist/css/main.css", 'utf8'),
+    css = fs.readFileSync("dist/css/base.css", 'utf8'),
     min = cssmin(css);
 
-fs.outputFileSync('dist/css/main.min.css', min, 'utf8');
+fs.outputFileSync('dist/css/base.min.css', min, 'utf8');


### PR DESCRIPTION
**What?**
Changing css compiled file name 

**Why?**
Minifier task was throwing an error because of an inaccurately named file.

Fixes #15 

ping @rapoulson 
