### PR TITLE
Fixing build

### DIFF
--- a/src/js/bookmarklet.js
+++ b/src/js/bookmarklet.js
@@ -77,6 +77,6 @@ function iFrame() {
 }
 
 module.exports = {
-    iFrame
+    iFrame: iFrame
 }
 

--- a/src/js/quote/KL.QuoteComposition.js
+++ b/src/js/quote/KL.QuoteComposition.js
@@ -92,8 +92,8 @@ KL.QuoteComposition = function() {
      * @param Object that = undefined(default)
      * @returns {undefined}
      */
-    _determineTextSize = function(that = undefined) {
-        that = that;
+    _determineTextSize = function(that) {
+        that = that || undefined;
         if (that !== undefined) {data = that.data;}
         var quote_detail = {
             sizeclass: "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,11 +17,25 @@ module.exports = {
         libraryTarget: 'var',
         library: "[name]"
     },
+    node: {
+        fs: "empty"
+    },
     resolve: {
         root: componentPath
     },
     resolveLoader: {
         root: path.join(__dirname, "node_modules")
+    },
+    module: {
+        loaders: [{
+            test: /\.hbs$/,
+            loader: __dirname + "../../../",
+            query: {
+                partialDirs: [
+                    path.join(__dirname, 'src', 'templates', 'layouts')
+                ]
+            }
+        }]
     }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,10 +6,13 @@ var webpack = require('webpack'),
 module.exports = {
     context: path.join(__dirname), 
     entry: {
-        bookmarklet: "./src/js/bookmarklet.js",
-        overlay: "./src/js/overlay.js",
-        compositions: "./src/js/compositions.js",
-        render: "./src/js/render.js"
+        vendor: [
+            'handlebars'    
+        ],
+        'bookmarklet': "./src/js/bookmarklet.js",
+        'overlay': "./src/js/overlay.js",
+        'compositions': "./src/js/compositions.js",
+        'render': "./src/js/render.js"
     },
     output: {
         path: path.join(__dirname, "./dist/js"),
@@ -17,25 +20,33 @@ module.exports = {
         libraryTarget: 'var',
         library: "[name]"
     },
+    module: {
+        loaders: [
+            {
+                test: /\.hbs$/,
+                loader: 'handlebars-loader'
+            }
+        ]
+    },
+    plugins: [
+        new webpack.optimize.CommonsChunkPlugin(
+            { name: 'commons', filename: 'common.js', minChunks: 0 }
+        )
+    ],
     node: {
         fs: "empty"
     },
     resolve: {
-        root: componentPath
+        root: componentPath,
+        alias: {
+            'handlebars': 'handlebars/runtime.js'
+        }
     },
     resolveLoader: {
-        root: path.join(__dirname, "node_modules")
-    },
-    module: {
-        loaders: [{
-            test: /\.hbs$/,
-            loader: __dirname + "../../../",
-            query: {
-                partialDirs: [
-                    path.join(__dirname, 'src', 'templates', 'layouts')
-                ]
-            }
-        }]
+        root: path.join(__dirname, "node_modules"),
+        alias: {
+            'hbs': 'handlebars-loader'
+        }
     }
 }
 


### PR DESCRIPTION
**What?**
Adding a handlebars loader to the webpack config and creates an empty module for fs so it runs w/o throwing an error. [Solution for fs error, courtesy of this comment](https://github.com/pugjs/pug-loader/issues/8#issuecomment-55568520). [Solution for hbs warning error courtesy of this comment](https://github.com/wycats/handlebars.js/issues/953#issuecomment-94931306)

**Why??**
This fixes the build issues we were having. Namely, the `missing fs module in hbs` error and the `WARNING in ./~/handlebars/lib/index.js require.extensions is not supported by webpack. Use a loader instead.` error. 

ping @rapoulson @scott2b 
