### PR TITLE
fix: Removing webpack chunks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,45 +5,28 @@ var webpack = require('webpack'),
 
 module.exports = {
     entry: {
-        vendor: [
-            'handlebars', 'lodash'
-        ],
-        'bookmarklet': "./src/js/bookmarklet.js",
-        'overlay': "./src/js/overlay.js",
-        'compositions': "./src/js/compositions.js",
-        'render': "./src/js/render.js"
+        bookmarklet: "./src/js/bookmarklet.js",
+        overlay: "./src/js/overlay.js",
+        compositions: "./src/js/compositions.js",
+        render: "./src/js/render.js"
     },
     output: {
         path: path.join(__dirname, "./dist/js"),
-        filename: "[name].js",
+        filename: "[name].js"
     },
-    module: {
-        loaders: [
-            {
-                test: /\.hbs$/,
-                loader: 'handlebars-loader'
-            }
-        ]
-    },
-    plugins: [
-        new webpack.ProvidePlugin({
-            _: "lodash"
-        }),
-        new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js', Infinity)
-    ],
     node: {
         fs: "empty"
     },
     resolve: {
         root: componentPath,
         alias: {
-            'handlebars': 'handlebars/runtime.js'
+            'handlebars': 'handlebars/dist/handlebars.js'
         }
     },
     resolveLoader: {
         root: path.join(__dirname, "node_modules"),
         alias: {
-            'hbs': 'handlebars-loader'
+            'hbs': 'handlebars'
         }
     }
 }


### PR DESCRIPTION
**What?**
Pulled out webpack chunking because it was causing more issues than helping. 

**Why?**
I don't think we were using chunking accurately. There are some idiosyncrasies with the way webpack does chunking that I think runs counter to our build. When chunking, order is very important. Unfortunately, in our build despite my best efforts, I couldn't figure out why the order was not as I expected which caused all sorts of issues. So I'm resolving to remove chunking altogether for the time being. 

ping @scott2b 
