### PR TITLE
Passes api root through to QuoteComposition; Fixes #37

### DIFF
--- a/src/js/bookmarklet.js
+++ b/src/js/bookmarklet.js
@@ -4,7 +4,7 @@
 function iFrame(apiRoot) {
     var Handlebars = require('handlebars');
 
-    function init(apiRoot) {
+    function init() {
         text = grabTextSelection();
         image = grabOgImage();
         cite = grabCitation();
@@ -56,11 +56,12 @@ function iFrame(apiRoot) {
     function composeURL(quote, image, cite) {
       //compositions.html?quote=whatever quote&image=assets/placeholder.jpg&cite=publication name
         var url,
+            a = "apiRoot=" + apiRoot,
             q = "quote=" + quote,
             i = "image=" + image,
             c = "cite=" + cite;
 
-        url = apiRoot + "compositions.html?" + q + "&" + i + "&" + c;
+        url = apiRoot + "compositions.html?" + q + "&" + i + "&" + c + "&" + a;
 
         return url;
     }

--- a/src/js/compositions.js
+++ b/src/js/compositions.js
@@ -38,7 +38,6 @@ KL.Pullquote = (function() {
         str = string.replace(match, '&');
       }
 
-      //urlVarArray = str.split('?')[1].split('&');
       urlVarArray = str.split('?').slice(1).join('?').split('&');
 
       for(var i = 0; i < urlVarArray.length; i++) {

--- a/src/js/compositions.js
+++ b/src/js/compositions.js
@@ -38,7 +38,8 @@ KL.Pullquote = (function() {
         str = string.replace(match, '&');
       }
 
-      urlVarArray = str.split('?')[1].split('&');
+      //urlVarArray = str.split('?')[1].split('&');
+      urlVarArray = str.split('?').slice(1).join('?').split('&');
 
       for(var i = 0; i < urlVarArray.length; i++) {
         urlKey = urlVarArray[i].split('=')[0];
@@ -57,6 +58,7 @@ KL.Pullquote = (function() {
      */
     createPullquoteContent = function(datum) {
         data = {
+            apiRoot: datum.apiRoot,
             quote: datum.quote || QUOTE,
             cite: datum.cite || CITE,
             image: datum.image || IMAGE,
@@ -99,7 +101,7 @@ KL.Pullquote = (function() {
                 options[i].position, options[i].use_image),
                 composeData = _.assign(data, layoutOptions);
 
-            KL.QuoteComposition().createPullquoteComposition(composeData, i);
+            KL.QuoteComposition(data.apiRoot).createPullquoteComposition(composeData, i);
         }
     };
 

--- a/src/js/dom/KL.DomEvent.js
+++ b/src/js/dom/KL.DomEvent.js
@@ -141,7 +141,7 @@ module.exports = {
         if (e.detail) {
             delta = -e.detail / 3;
         }
-        
+
         return delta;
     }
 };

--- a/src/js/quote/KL.QuoteComposition.js
+++ b/src/js/quote/KL.QuoteComposition.js
@@ -49,7 +49,7 @@ KL.QuoteComposition = function(apiRoot) {
         if (root === 'http://localhost:8080/') {
             // TODO: build out development platform to run screenshot locally
             // and to enable localhost integration with screenshot. This fix
-            // to root is a stopgap measure.
+            // to root is a stopgap measure. See issue #40
             root = 'http://pullquote.knilab.com/';
         }
         _callScreenshot(root + 'render.html?', data);

--- a/src/js/quote/KL.QuoteComposition.js
+++ b/src/js/quote/KL.QuoteComposition.js
@@ -10,7 +10,7 @@ module.exports = KL.Class.extend({
     includes: [KL.Events, KL.DomMixins, KL.Helper]
 })
 
-KL.QuoteComposition = function() {
+KL.QuoteComposition = function(apiRoot) {
     //var Handlebars = require('handlebars'),
     var data;
 
@@ -45,7 +45,14 @@ KL.QuoteComposition = function() {
     },
 
     _onDownload = function(e) {
-        _callScreenshot('http://pullquote.knilab.com/render.html?', data);
+        var root = apiRoot;
+        if (root === 'http://localhost:8080/') {
+            // TODO: build out development platform to run screenshot locally
+            // and to enable localhost integration with screenshot. This fix
+            // to root is a stopgap measure.
+            root = 'http://pullquote.knilab.com/';
+        }
+        _callScreenshot(root + 'render.html?', data);
     },
 
     _encodeURL = function(url) {

--- a/src/templates/compositions.hbs
+++ b/src/templates/compositions.hbs
@@ -23,6 +23,6 @@ title: "Pullquote Compositions"
     </div>
 </script>
 {{{{/raw-helper}}}}
+<script src="{{{apiRoot}}}js/compositions.js"></script>
 
-<script src="js/compositions.js"></script>
 


### PR DESCRIPTION
**What?**
Pass the apiRoot through composition to the QuoteComposition code

**Why?**
endpoints should not be hardcoded. The current approach still effectively hardcodes development to use a staging endpoint to pass to screenshot. This is done so that screenshotting still works in development, but this new implementation passes the correct endpoint through and only swaps it out in the case of local development at the last moment, thus shifting the burden of this issue from a coding issue to a development infrastructure issue.

**Reviewers**
@shortdiv 
