### PR TITLE
Fixes citation to use full document.domain sans www; Fixes #33

### DIFF
--- a/src/js/bookmarklet.js
+++ b/src/js/bookmarklet.js
@@ -48,8 +48,10 @@ function iFrame(apiRoot) {
     }
 
     function grabCitation(){
-      var cite;
-      document.domain.split("\.")[0];
+      var cite = document.domain;
+      if (cite.indexOf('www.') == 0) {
+          cite = cite.slice(4);
+      }
       return cite;
     }
 


### PR DESCRIPTION
**What?**
Fix citation to be the document.domain w/out any prefixing www.

**Why?**
citation implementation was not returning any value. Opted against previous approach of slicing the domain. I'd like to see examples of what an undesirable long domain looks like before doctoring it

**Reviewers**
@rapoulson 
